### PR TITLE
[MINOR UPDATE] close HttpResponse in HttpCollectImpl

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/http/HttpCollectImpl.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/http/HttpCollectImpl.java
@@ -286,9 +286,10 @@ public class HttpCollectImpl extends AbstractCollect {
             long startTime = System.currentTimeMillis();
             try {
                 HttpGet httpGet = new HttpGet(siteUrl);
-                CloseableHttpResponse response = CommonHttpClient.getHttpClient().execute(httpGet);
-                statusCode = response.getStatusLine().getStatusCode();
-                EntityUtils.consume(response.getEntity());
+                try (CloseableHttpResponse response = CommonHttpClient.getHttpClient().execute(httpGet)) {
+                    statusCode = response.getStatusLine().getStatusCode();
+                    EntityUtils.consume(response.getEntity());
+                }
             } catch (ClientProtocolException e1) {
                 if (e1.getCause() != null) {
                     errorMsg = e1.getCause().getMessage();


### PR DESCRIPTION
## What's changed?

CloseableHttpResponse instance should be closed.


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
